### PR TITLE
Support for message inputs in expression service

### DIFF
--- a/src/main/java/com/adaptris/expressions/ExpressionService.java
+++ b/src/main/java/com/adaptris/expressions/ExpressionService.java
@@ -26,6 +26,8 @@ import com.adaptris.core.CoreException;
 import com.adaptris.core.Service;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.InputFieldExpression;
+import org.apache.commons.lang3.StringUtils;
 import com.adaptris.core.common.MetadataDataOutputParameter;
 import com.adaptris.interlok.config.DataInputParameter;
 import com.adaptris.interlok.config.DataOutputParameter;
@@ -77,6 +79,16 @@ import bsh.Interpreter;
  * "key1", before finally dividing the result by the numerical value of the metadata item named "key2".
  * </p>
  * <p>
+ * A further example using the AdaptrisMessage.resolve() function allows us to create algorithms where the values are stored in metadata;
+ *
+ * <pre>
+ *   ((%message{key1} * %message{key2}) * %message{key3})
+ * </pre>
+ *
+ * Lets assume that the values for the metadata items identified by the keys 'key1', 'key2' and 'key3' are all "10", then again the result
+ * will be 1000.
+ * </p>
+ * <p>
  * Additionally you can also perform boolean calculations. To do this, you will need to override the result-formatter. By default we use
  * {@link NumericalResultFormatter}, for algorithms that return true or false, you will need to set the result-formatter to
  * boolean-result-formatter ({@link BooleanResultFormatter})
@@ -124,6 +136,7 @@ public class ExpressionService extends ServiceImp {
   @Override
   public void doService(AdaptrisMessage msg) throws ServiceException {
     Interpreter interpreter = new Interpreter();
+    String algorithm = getAlgorithm();
 
     try {
       for (int counter = 0; counter < getParameters().size(); counter++) {
@@ -139,10 +152,15 @@ public class ExpressionService extends ServiceImp {
         interpreter.set("$" + (counter + 1), extractedValue);
       }
 
-      interpreter.eval("result = (" + getAlgorithm() + ")");
+      //Check and evaluate if algorithm is an expression
+      if(StringUtils.isNotBlank(algorithm) && InputFieldExpression.isExpression(algorithm)) {
+        algorithm = msg.resolve(algorithm);
+      }
+
+      interpreter.eval("result = (" + algorithm + ")");
 
       String stringResult = getResultFormatter().format(interpreter.get("result"));
-      log.trace(getAlgorithm() + " evaluated to :" + stringResult);
+      log.trace(algorithm + " evaluated to :" + stringResult);
 
       result.insert(stringResult, msg);
     } catch (Exception ex) {

--- a/src/test/java/com/adaptris/expressions/ExpresssionServiceTest.java
+++ b/src/test/java/com/adaptris/expressions/ExpresssionServiceTest.java
@@ -125,6 +125,25 @@ public class ExpresssionServiceTest extends ExampleServiceCase {
   }
 
   @Test
+  public void testBooleanEqualsResolveResult() throws Exception {
+    List<DataInputParameter<String>> parameters = new ArrayList<>();
+
+    service.setParameters(parameters);
+    service.setAlgorithm("%message{key1} == %message{key2}");
+    service.setResult(new MetadataDataOutputParameter("customKey"));
+    service.setResultFormatter(new BooleanResultFormatter());
+
+    AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+    adaptrisMessage.addMessageHeader("key1", "20");
+    adaptrisMessage.addMessageHeader("key2", "20");
+
+
+    execute(service, adaptrisMessage);
+
+    assertEquals("true", adaptrisMessage.getMetadataValue("customKey"));
+  }
+
+  @Test
   public void testBooleanNotEqualsResult() throws Exception {
     ConstantDataInputParameter constantDataInputParameterOne = new ConstantDataInputParameter("50");
     ConstantDataInputParameter constantDataInputParameterTwo = new ConstantDataInputParameter("20");
@@ -139,6 +158,25 @@ public class ExpresssionServiceTest extends ExampleServiceCase {
     service.setResultFormatter(new BooleanResultFormatter());
 
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+
+    execute(service, adaptrisMessage);
+
+    assertEquals("false", adaptrisMessage.getMetadataValue("customKey"));
+  }
+
+  @Test
+  public void testBooleanNotEqualsResolveResult() throws Exception {
+    List<DataInputParameter<String>> parameters = new ArrayList<>();
+
+    service.setParameters(parameters);
+    service.setAlgorithm("%message{key1} == %message{key2}");
+    service.setResult(new MetadataDataOutputParameter("customKey"));
+    service.setResultFormatter(new BooleanResultFormatter());
+
+    AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+
+    adaptrisMessage.addMessageHeader("key1", "10");
+    adaptrisMessage.addMessageHeader("key2", "20");
 
     execute(service, adaptrisMessage);
 
@@ -167,6 +205,25 @@ public class ExpresssionServiceTest extends ExampleServiceCase {
   }
 
   @Test
+  public void testBooleanGreaterResolveResult() throws Exception {
+    List<DataInputParameter<String>> parameters = new ArrayList<>();
+
+    service.setParameters(parameters);
+    service.setAlgorithm("%message{key1} > %message{key2}");
+    service.setResult(new MetadataDataOutputParameter("customKey"));
+    service.setResultFormatter(new BooleanResultFormatter());
+
+    AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+
+    adaptrisMessage.addMessageHeader("key1", "20");
+    adaptrisMessage.addMessageHeader("key2", "10");
+
+    execute(service, adaptrisMessage);
+
+    assertEquals("true", adaptrisMessage.getMetadataValue("customKey"));
+  }
+
+  @Test
   public void testBooleanNotGreaterResult() throws Exception {
     ConstantDataInputParameter constantDataInputParameterOne = new ConstantDataInputParameter("10");
     ConstantDataInputParameter constantDataInputParameterTwo = new ConstantDataInputParameter("20");
@@ -181,6 +238,25 @@ public class ExpresssionServiceTest extends ExampleServiceCase {
     service.setResultFormatter(new BooleanResultFormatter());
 
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+
+    execute(service, adaptrisMessage);
+
+    assertEquals("false", adaptrisMessage.getMetadataValue("customKey"));
+  }
+
+  @Test
+  public void testBooleanNotGreaterResolveResult() throws Exception {
+    List<DataInputParameter<String>> parameters = new ArrayList<>();
+
+    service.setParameters(parameters);
+    service.setAlgorithm("%message{key1} > %message{key2}");
+    service.setResult(new MetadataDataOutputParameter("customKey"));
+    service.setResultFormatter(new BooleanResultFormatter());
+
+    AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+
+    adaptrisMessage.addMessageHeader("key1", "10");
+    adaptrisMessage.addMessageHeader("key2", "20");
 
     execute(service, adaptrisMessage);
 
@@ -209,6 +285,25 @@ public class ExpresssionServiceTest extends ExampleServiceCase {
   }
 
   @Test
+  public void testBooleanLessResolveResult() throws Exception {
+    List<DataInputParameter<String>> parameters = new ArrayList<>();
+
+    service.setParameters(parameters);
+    service.setAlgorithm("%message{key1} < %message{key2}");
+    service.setResult(new MetadataDataOutputParameter("customKey"));
+    service.setResultFormatter(new BooleanResultFormatter());
+
+    AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+
+    adaptrisMessage.addMessageHeader("key1", "10");
+    adaptrisMessage.addMessageHeader("key2", "20");
+
+    execute(service, adaptrisMessage);
+
+    assertEquals("true", adaptrisMessage.getMetadataValue("customKey"));
+  }
+
+  @Test
   public void testBooleanNotLessResult() throws Exception {
     ConstantDataInputParameter constantDataInputParameterOne = new ConstantDataInputParameter("30");
     ConstantDataInputParameter constantDataInputParameterTwo = new ConstantDataInputParameter("20");
@@ -223,6 +318,25 @@ public class ExpresssionServiceTest extends ExampleServiceCase {
     service.setResultFormatter(new BooleanResultFormatter());
 
     AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+
+    execute(service, adaptrisMessage);
+
+    assertEquals("false", adaptrisMessage.getMetadataValue("customKey"));
+  }
+
+  @Test
+  public void testBooleanNotLessResolveResult() throws Exception {
+    List<DataInputParameter<String>> parameters = new ArrayList<>();
+
+    service.setParameters(parameters);
+    service.setAlgorithm("%message{key1} < %message{key2}");
+    service.setResult(new MetadataDataOutputParameter("customKey"));
+    service.setResultFormatter(new BooleanResultFormatter());
+
+    AdaptrisMessage adaptrisMessage = DefaultMessageFactory.getDefaultInstance().newMessage();
+
+    adaptrisMessage.addMessageHeader("key1", "30");
+    adaptrisMessage.addMessageHeader("key2", "20");
 
     execute(service, adaptrisMessage);
 


### PR DESCRIPTION
## Motivation

Why am I doing this

## Modification

What did I change

## PR Checklist

- [x] been self-reviewed.
- [x] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [x] Checked that new 3rd party dependencies are appropriately licensed
- [x] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [x] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user

## Testing

How can I test this if I'm reviewing this.
